### PR TITLE
until-condition-example-1.bash

### DIFF
--- a/until-condition-example-1.bash
+++ b/until-condition-example-1.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Author: Abhishek Balaji
+# Date of creation: 11-05-2025 / 12:21 PM
+
+: 'Problem Statement: Print Numbers Using until Loop'
+
+num=1
+
+until [ "$num" -ge 8 ]
+do
+  echo $num
+  (( num = num + 1 ))
+done
+
+# Keynote: In until condition, it will loop until the condition becomes true
+# For string comparison, follows this syntax format [ "$x" -eq "$y" ]. For numeric comparison, use this syntax format (( a==b ))
+


### PR DESCRIPTION
Implement an until loop in Bash to print numbers from 1 to 8. The loop continues until the condition num -gt 8 is satisfied

![Screenshot 2025-05-11 122956](https://github.com/user-attachments/assets/b429201c-cef1-430e-8d73-23e2bc15e549)
