### PR TITLE
trap-remove-file.bash is added

### DIFF
--- a/trapping-signals/trap-remove-file.bash
+++ b/trapping-signals/trap-remove-file.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Trap EXIT signal and delete hello.txt when the script exits
+trap "rm -f hello.txt" EXIT
+
+# Create a file named hello.txt
+touch hello.txt
+
+# List the file to confirm it exists
+ls -l
+
+# What this does:
+# When the script is run, it creates a file named hello.txt.
+
+# The trap command ensures that when the script ends, hello.txt is automatically deleted.
+
+# The EXIT signal covers normal termination as well as exiting due to errors (except if killed by kill -9).


### PR DESCRIPTION
This bash script demonstrates how to use the trap command to clean up resources (in this case, a file) when the script exits.